### PR TITLE
Add reactive notebook service

### DIFF
--- a/BE/notebook-service/build.gradle
+++ b/BE/notebook-service/build.gradle
@@ -18,11 +18,11 @@ repositories {
 }
 
 dependencies {
-    // HTTP API (REST)
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Reactive Web API
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    // MongoDB
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    // Reactive MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
     // Spring Security + JWT validation
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.0'
 }
 
 tasks.named('test') {

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/config/SecurityConfig.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package org.neobook.notebookservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchange -> exchange
+                        .pathMatchers("/actuator/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .oauth2ResourceServer(ServerHttpSecurity.OAuth2ResourceServerSpec::jwt);
+        return http.build();
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/config/WebClientConfig.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/config/WebClientConfig.java
@@ -1,0 +1,27 @@
+package org.neobook.notebookservice.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+
+    @Bean
+    @Qualifier("userServiceClient")
+    public WebClient userServiceClient(WebClient.Builder builder) {
+        return builder.baseUrl("http://user-service:8081/api").build();
+    }
+
+    @Bean
+    @Qualifier("schoolServiceClient")
+    public WebClient schoolServiceClient(WebClient.Builder builder) {
+        return builder.baseUrl("http://school-service:8082/api").build();
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/controller/AbsenceController.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/controller/AbsenceController.java
@@ -1,0 +1,47 @@
+package org.neobook.notebookservice.controller;
+
+import org.neobook.notebookservice.dto.AbsenceDto;
+import org.neobook.notebookservice.dto.CreateAbsenceDto;
+import org.neobook.notebookservice.dto.UpdateAbsenceDto;
+import org.neobook.notebookservice.service.AbsenceService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/absences")
+public class AbsenceController {
+
+    private final AbsenceService service;
+
+    public AbsenceController(AbsenceService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN','STUDENT','PARENT')")
+    public Flux<AbsenceDto> getAbsences(@RequestParam("studentId") UUID studentId) {
+        return service.getAbsencesByStudent(studentId);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<AbsenceDto> create(@RequestBody CreateAbsenceDto dto) {
+        return service.create(dto);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<AbsenceDto> update(@PathVariable String id, @RequestBody UpdateAbsenceDto dto) {
+        return service.update(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<Void> delete(@PathVariable String id) {
+        return service.delete(id);
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/controller/GradeController.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/controller/GradeController.java
@@ -1,0 +1,47 @@
+package org.neobook.notebookservice.controller;
+
+import org.neobook.notebookservice.dto.CreateGradeDto;
+import org.neobook.notebookservice.dto.GradeDto;
+import org.neobook.notebookservice.dto.UpdateGradeDto;
+import org.neobook.notebookservice.service.GradeService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/grades")
+public class GradeController {
+
+    private final GradeService service;
+
+    public GradeController(GradeService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN','STUDENT','PARENT')")
+    public Flux<GradeDto> getGrades(@RequestParam("studentId") UUID studentId) {
+        return service.getGradesByStudent(studentId);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<GradeDto> create(@RequestBody CreateGradeDto dto) {
+        return service.create(dto);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<GradeDto> update(@PathVariable String id, @RequestBody UpdateGradeDto dto) {
+        return service.update(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('TEACHER','HEADMASTER','ADMIN')")
+    public Mono<Void> delete(@PathVariable String id) {
+        return service.delete(id);
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/AbsenceDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/AbsenceDto.java
@@ -1,0 +1,13 @@
+package org.neobook.notebookservice.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record AbsenceDto(
+        String id,
+        UUID studentId,
+        UUID teacherId,
+        Long subjectId,
+        LocalDate date,
+        boolean excused
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/CreateAbsenceDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/CreateAbsenceDto.java
@@ -1,0 +1,12 @@
+package org.neobook.notebookservice.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CreateAbsenceDto(
+        UUID studentId,
+        UUID teacherId,
+        Long subjectId,
+        LocalDate date,
+        boolean excused
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/CreateGradeDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/CreateGradeDto.java
@@ -1,0 +1,12 @@
+package org.neobook.notebookservice.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CreateGradeDto(
+        UUID studentId,
+        UUID teacherId,
+        Long subjectId,
+        int value,
+        LocalDate date
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/GradeDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/GradeDto.java
@@ -1,0 +1,13 @@
+package org.neobook.notebookservice.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record GradeDto(
+        String id,
+        UUID studentId,
+        UUID teacherId,
+        Long subjectId,
+        int value,
+        LocalDate date
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/UpdateAbsenceDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/UpdateAbsenceDto.java
@@ -1,0 +1,5 @@
+package org.neobook.notebookservice.dto;
+
+public record UpdateAbsenceDto(
+        Boolean excused
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/UpdateGradeDto.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/dto/UpdateGradeDto.java
@@ -1,0 +1,8 @@
+package org.neobook.notebookservice.dto;
+
+import java.time.LocalDate;
+
+public record UpdateGradeDto(
+        Integer value,
+        LocalDate date
+) {}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/mapper/AbsenceMapper.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/mapper/AbsenceMapper.java
@@ -1,0 +1,20 @@
+package org.neobook.notebookservice.mapper;
+
+import org.mapstruct.*;
+import org.neobook.notebookservice.dto.AbsenceDto;
+import org.neobook.notebookservice.dto.CreateAbsenceDto;
+import org.neobook.notebookservice.dto.UpdateAbsenceDto;
+import org.neobook.notebookservice.model.Absence;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.FIELD,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AbsenceMapper {
+
+    AbsenceDto toDto(Absence entity);
+
+    @Mapping(target = "id", ignore = true)
+    Absence toEntity(CreateAbsenceDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(UpdateAbsenceDto dto, @MappingTarget Absence entity);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/mapper/GradeMapper.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/mapper/GradeMapper.java
@@ -1,0 +1,20 @@
+package org.neobook.notebookservice.mapper;
+
+import org.mapstruct.*;
+import org.neobook.notebookservice.dto.CreateGradeDto;
+import org.neobook.notebookservice.dto.GradeDto;
+import org.neobook.notebookservice.dto.UpdateGradeDto;
+import org.neobook.notebookservice.model.Grade;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.FIELD,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface GradeMapper {
+
+    GradeDto toDto(Grade entity);
+
+    @Mapping(target = "id", ignore = true)
+    Grade toEntity(CreateGradeDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updateEntity(UpdateGradeDto dto, @MappingTarget Grade entity);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/model/Absence.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/model/Absence.java
@@ -1,0 +1,66 @@
+package org.neobook.notebookservice.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Document(collection = "absences")
+public class Absence {
+    @Id
+    private String id;
+    private UUID studentId;
+    private UUID teacherId;
+    private Long subjectId;
+    private LocalDate date;
+    private boolean excused;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public UUID getStudentId() {
+        return studentId;
+    }
+
+    public void setStudentId(UUID studentId) {
+        this.studentId = studentId;
+    }
+
+    public UUID getTeacherId() {
+        return teacherId;
+    }
+
+    public void setTeacherId(UUID teacherId) {
+        this.teacherId = teacherId;
+    }
+
+    public Long getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(Long subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public boolean isExcused() {
+        return excused;
+    }
+
+    public void setExcused(boolean excused) {
+        this.excused = excused;
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/model/Grade.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/model/Grade.java
@@ -1,0 +1,66 @@
+package org.neobook.notebookservice.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Document(collection = "grades")
+public class Grade {
+    @Id
+    private String id;
+    private UUID studentId;
+    private UUID teacherId;
+    private Long subjectId;
+    private int value;
+    private LocalDate date;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public UUID getStudentId() {
+        return studentId;
+    }
+
+    public void setStudentId(UUID studentId) {
+        this.studentId = studentId;
+    }
+
+    public UUID getTeacherId() {
+        return teacherId;
+    }
+
+    public void setTeacherId(UUID teacherId) {
+        this.teacherId = teacherId;
+    }
+
+    public Long getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(Long subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/repository/AbsenceRepository.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/repository/AbsenceRepository.java
@@ -1,0 +1,11 @@
+package org.neobook.notebookservice.repository;
+
+import org.neobook.notebookservice.model.Absence;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+public interface AbsenceRepository extends ReactiveMongoRepository<Absence, String> {
+    Flux<Absence> findAllByStudentId(UUID studentId);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/repository/GradeRepository.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/repository/GradeRepository.java
@@ -1,0 +1,11 @@
+package org.neobook.notebookservice.repository;
+
+import org.neobook.notebookservice.model.Grade;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+public interface GradeRepository extends ReactiveMongoRepository<Grade, String> {
+    Flux<Grade> findAllByStudentId(UUID studentId);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/AbsenceService.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/AbsenceService.java
@@ -1,0 +1,16 @@
+package org.neobook.notebookservice.service;
+
+import org.neobook.notebookservice.dto.AbsenceDto;
+import org.neobook.notebookservice.dto.CreateAbsenceDto;
+import org.neobook.notebookservice.dto.UpdateAbsenceDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+public interface AbsenceService {
+    Flux<AbsenceDto> getAbsencesByStudent(UUID studentId);
+    Mono<AbsenceDto> create(CreateAbsenceDto dto);
+    Mono<AbsenceDto> update(String id, UpdateAbsenceDto dto);
+    Mono<Void> delete(String id);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/AbsenceServiceImpl.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/AbsenceServiceImpl.java
@@ -1,0 +1,53 @@
+package org.neobook.notebookservice.service;
+
+import org.neobook.notebookservice.dto.AbsenceDto;
+import org.neobook.notebookservice.dto.CreateAbsenceDto;
+import org.neobook.notebookservice.dto.UpdateAbsenceDto;
+import org.neobook.notebookservice.mapper.AbsenceMapper;
+import org.neobook.notebookservice.model.Absence;
+import org.neobook.notebookservice.repository.AbsenceRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+public class AbsenceServiceImpl implements AbsenceService {
+
+    private final AbsenceRepository repository;
+    private final AbsenceMapper mapper;
+
+    public AbsenceServiceImpl(AbsenceRepository repository, AbsenceMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Flux<AbsenceDto> getAbsencesByStudent(UUID studentId) {
+        return repository.findAllByStudentId(studentId)
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<AbsenceDto> create(CreateAbsenceDto dto) {
+        Absence entity = mapper.toEntity(dto);
+        return repository.save(entity)
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<AbsenceDto> update(String id, UpdateAbsenceDto dto) {
+        return repository.findById(id)
+                .flatMap(existing -> {
+                    mapper.updateEntity(dto, existing);
+                    return repository.save(existing);
+                })
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<Void> delete(String id) {
+        return repository.deleteById(id);
+    }
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/GradeService.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/GradeService.java
@@ -1,0 +1,16 @@
+package org.neobook.notebookservice.service;
+
+import org.neobook.notebookservice.dto.CreateGradeDto;
+import org.neobook.notebookservice.dto.GradeDto;
+import org.neobook.notebookservice.dto.UpdateGradeDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+public interface GradeService {
+    Flux<GradeDto> getGradesByStudent(UUID studentId);
+    Mono<GradeDto> create(CreateGradeDto dto);
+    Mono<GradeDto> update(String id, UpdateGradeDto dto);
+    Mono<Void> delete(String id);
+}

--- a/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/GradeServiceImpl.java
+++ b/BE/notebook-service/src/main/java/org/neobook/notebookservice/service/GradeServiceImpl.java
@@ -1,0 +1,53 @@
+package org.neobook.notebookservice.service;
+
+import org.neobook.notebookservice.dto.CreateGradeDto;
+import org.neobook.notebookservice.dto.GradeDto;
+import org.neobook.notebookservice.dto.UpdateGradeDto;
+import org.neobook.notebookservice.mapper.GradeMapper;
+import org.neobook.notebookservice.model.Grade;
+import org.neobook.notebookservice.repository.GradeRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+public class GradeServiceImpl implements GradeService {
+
+    private final GradeRepository repository;
+    private final GradeMapper mapper;
+
+    public GradeServiceImpl(GradeRepository repository, GradeMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Flux<GradeDto> getGradesByStudent(UUID studentId) {
+        return repository.findAllByStudentId(studentId)
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<GradeDto> create(CreateGradeDto dto) {
+        Grade entity = mapper.toEntity(dto);
+        return repository.save(entity)
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<GradeDto> update(String id, UpdateGradeDto dto) {
+        return repository.findById(id)
+                .flatMap(existing -> {
+                    mapper.updateEntity(dto, existing);
+                    return repository.save(existing);
+                })
+                .map(mapper::toDto);
+    }
+
+    @Override
+    public Mono<Void> delete(String id) {
+        return repository.deleteById(id);
+    }
+}

--- a/BE/notebook-service/src/main/resources/application.properties
+++ b/BE/notebook-service/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8083
 spring.application.name=notebook-service
 
 # MongoDB URI
-spring.data.mongodb.uri=mongodb://mongo:27017/NeoBook
+spring.data.mongodb.uri=mongodb://mongo:27017/notebook
 
 # Resource Server ? JWT ????????? ?????? Keycloak ? Docker
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/NeoBook


### PR DESCRIPTION
## Summary
- implement new reactive notebook service using MongoDB and WebFlux
- configure security and reactive repositories
- add DTOs, mappers, services, and controllers
- update build file for reactive dependencies
- configure MongoDB URI