### PR TITLE
Add Testcontainers for integration tests

### DIFF
--- a/BE/notebook-service/build.gradle
+++ b/BE/notebook-service/build.gradle
@@ -36,7 +36,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.0'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+    testImplementation 'org.testcontainers:mongodb:1.19.3'
 }
 
 tasks.named('test') {

--- a/BE/notebook-service/src/test/java/org/neobook/notebookservice/GradeControllerIntegrationTest.java
+++ b/BE/notebook-service/src/test/java/org/neobook/notebookservice/GradeControllerIntegrationTest.java
@@ -1,0 +1,66 @@
+package org.neobook.notebookservice;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neobook.notebookservice.model.Grade;
+import org.neobook.notebookservice.repository.GradeRepository;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+
+@Testcontainers
+@SpringBootTest(properties = "spring.profiles.active=test", webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@org.springframework.test.context.ActiveProfiles("test")
+class GradeControllerIntegrationTest {
+
+    @Container
+    static MongoDBContainer mongo = new MongoDBContainer("mongo:6");
+
+    @DynamicPropertySource
+    static void mongoProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private GradeRepository gradeRepository;
+
+    private UUID studentId;
+
+    @BeforeEach
+    void setup() {
+        gradeRepository.deleteAll().block();
+        studentId = UUID.randomUUID();
+        Grade g = new Grade();
+        g.setStudentId(studentId);
+        g.setTeacherId(UUID.randomUUID());
+        g.setSubjectId(1L);
+        g.setValue(5);
+        g.setDate(LocalDate.now());
+        gradeRepository.save(g).block();
+    }
+
+    @Test
+    void getGradesReturnsData() {
+        webTestClient.mutateWith(SecurityMockServerConfigurers.mockJwt().jwt(jwt -> jwt.claim("roles", java.util.List.of("ROLE_STUDENT"))))
+                .get().uri(uriBuilder -> uriBuilder.path("/api/grades").queryParam("studentId", studentId).build())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].studentId").isEqualTo(studentId.toString());
+    }
+}

--- a/BE/notebook-service/src/test/resources/application-test.properties
+++ b/BE/notebook-service/src/test/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://dummy
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://dummy

--- a/BE/user-service/build.gradle
+++ b/BE/user-service/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(23)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -44,6 +44,8 @@ dependencies {
     /* --- Тестове --- */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+    testImplementation 'org.testcontainers:postgresql:1.19.3'
 }
 
 tasks.named('test') {

--- a/BE/user-service/src/test/java/org/neobook/userservice/StudentControllerIntegrationTest.java
+++ b/BE/user-service/src/test/java/org/neobook/userservice/StudentControllerIntegrationTest.java
@@ -1,0 +1,79 @@
+package org.neobook.userservice;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.neobook.userservice.model.Student;
+import org.neobook.userservice.repository.StudentRepository;
+import org.neobook.userservice.service.KeycloakService;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Testcontainers
+@SpringBootTest(properties = "spring.profiles.active=test", webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@org.springframework.test.context.ActiveProfiles("test")
+class StudentControllerIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14")
+            .withDatabaseName("user_service")
+            .withUsername("postgres")
+            .withPassword("")
+            .withInitScript("schema.sql");
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StudentRepository studentRepository;
+
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private KeycloakService keycloakService;
+
+    private UUID kcId;
+
+    @BeforeEach
+    void setup() {
+        studentRepository.deleteAll();
+        Student s = new Student();
+        kcId = UUID.randomUUID();
+        s.setKeycloakUserId(kcId);
+        s.setPhone("123");
+        studentRepository.save(s);
+        UserRepresentation user = new UserRepresentation();
+        user.setFirstName("Test");
+        user.setLastName("Student");
+        org.mockito.Mockito.when(keycloakService.getUser(kcId)).thenReturn(user);
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void getStudentsReturnsData() throws Exception {
+        mockMvc.perform(get("/api/students"))
+                .andDo(org.springframework.test.web.servlet.result.MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].keycloakUserId").value(kcId.toString()));
+    }
+}

--- a/BE/user-service/src/test/java/org/neobook/userservice/UserServiceApplicationTests.java
+++ b/BE/user-service/src/test/java/org/neobook/userservice/UserServiceApplicationTests.java
@@ -2,9 +2,30 @@ package org.neobook.userservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @SpringBootTest
+@org.springframework.test.context.ActiveProfiles("test")
 class UserServiceApplicationTests {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14")
+            .withDatabaseName("user_service")
+            .withUsername("postgres")
+            .withPassword("")
+            .withInitScript("schema.sql");
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
 
     @Test
     void contextLoads() {

--- a/BE/user-service/src/test/resources/application-test.properties
+++ b/BE/user-service/src/test/resources/application-test.properties
@@ -1,0 +1,4 @@
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.default_schema=user_service
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://dummy
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://dummy

--- a/BE/user-service/src/test/resources/schema.sql
+++ b/BE/user-service/src/test/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS user_service;


### PR DESCRIPTION
## Summary
- switch user-service tests to use a PostgreSQL Testcontainer
- update notebook-service tests to use a MongoDB Testcontainer
- remove embedded database configs
- add SQL script for schema creation in tests

## Testing
- `./gradlew test --no-daemon` in `BE/user-service` *(fails: Docker not available)*
- `./gradlew test --no-daemon` in `BE/notebook-service` *(fails: Docker not available)*
